### PR TITLE
Fix AutoPTRs ending up in unrelated zones

### DIFF
--- a/pdnscontrol/__init__.py
+++ b/pdnscontrol/__init__.py
@@ -65,6 +65,7 @@ js_libs = [
 js_libs_files = ['bower_components/'+x for x in js_libs]
 asset_env.register('js_libs', *js_libs_files, output='gen/js-libs-%(version)s.js')
 js_app = [
+    "polyfill.js",
     "util.js",
     "components.js",
     "popup.js",

--- a/pdnscontrol/static/js/controllers.zone.js
+++ b/pdnscontrol/static/js/controllers.zone.js
@@ -72,7 +72,10 @@ angular.module('ControlApp.controllers.zone').controller('ZoneDetailCtrl',
     // If not, we discard it.
     // Also start fetching the reverse zones already.
     _.each(possiblePtrs, function(ptr) {
-      var matchingZones = _.sortBy(_.filter($scope.zones, function(z) { return ptr.revName.indexOf(z.name) != -1; }), function(z) { return z.name }).reverse();
+      var matchingZones = _.filter($scope.zones, function(z) {
+        return ptr.revName.endsWith('.' + z.name);
+      });
+      matchingZones = _.sortBy(matchingZones, function(z) { return z.name });
       if (matchingZones.length === 0) {
         return;
       }

--- a/pdnscontrol/static/js/polyfill.js
+++ b/pdnscontrol/static/js/polyfill.js
@@ -1,0 +1,12 @@
+// str.endsWith polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Browser_compatibility
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+      var subjectString = this.toString();
+      if (position === undefined || position > subjectString.length) {
+        position = subjectString.length;
+      }
+      position -= searchString.length;
+      var lastIndex = subjectString.indexOf(searchString, position);
+      return lastIndex !== -1 && lastIndex === position;
+  };
+}


### PR DESCRIPTION
Because we were using revname.indexOf(zonename) with no further
restrictions, AutoPTR RRs could end up in completely unrelated
zones.

Fixes #112.

Thanks to Kaito Kumashiro (@kumashiro).
