### PR TITLE
Minor README fixes

### DIFF
--- a/pdnsmgrd/README.markdown
+++ b/pdnsmgrd/README.markdown
@@ -67,9 +67,9 @@ Any method supported by the upstream server. Result format will be determined by
 
 ## sudo configuration Example
 
-    pdnsmgr ALL = NOPASSWD: /usr/sbin/service pdns restart
-    pdnsmgr ALL = NOPASSWD: /usr/sbin/service pdns-recursor restart
-    pdnsmgr ALL = NOPASSWD: /usr/sbin/service pdns stop
-    pdnsmgr ALL = NOPASSWD: /usr/sbin/service pdns-recursor stop
-    pdnsmgr ALL = NOPASSWD: /usr/sbin/service pdns start
-    pdnsmgr ALL = NOPASSWD: /usr/sbin/service pdns-recursor start
+    pdnsmgrd ALL = NOPASSWD: /usr/sbin/service pdns restart
+    pdnsmgrd ALL = NOPASSWD: /usr/sbin/service pdns-recursor restart
+    pdnsmgrd ALL = NOPASSWD: /usr/sbin/service pdns stop
+    pdnsmgrd ALL = NOPASSWD: /usr/sbin/service pdns-recursor stop
+    pdnsmgrd ALL = NOPASSWD: /usr/sbin/service pdns start
+    pdnsmgrd ALL = NOPASSWD: /usr/sbin/service pdns-recursor start

--- a/pdnsmgrd/README.markdown
+++ b/pdnsmgrd/README.markdown
@@ -46,7 +46,7 @@ POST with `application/x-www-form-urlencoded`. Result will be JSON or JSONP (see
 
 #### Example
 
-    curl -k -u 'secret:sikrit' 'https://localhost:8084/manage/restart'
+    curl -d '' -k -u 'secret:sikrit' 'https://localhost:8084/manage/restart'
     {"cmdline": ["sudo", "service", "pdns", "restart"], "success": true, "output": "Restarting pdns (via systemctl): pdns.service.\n"}
 
 


### PR DESCRIPTION
Fixes for a couple of minor problems in the README I found while installing.

I tried to use -X POST for the curl stanza at first but the server got upset that there was no CONTENT_LENGTH set. -d '' seems to work fine.